### PR TITLE
Play more nicely with other combat modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0
+
+### Fixed
+
+-   Addressed some compatibility issues with other combat modules
+
 ## 0.1.3
 
 ### Fixed

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
     "name": "hidden-initiative",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "title": "Hidden Initiative",
     "description": "Enables hiding initiative values and dice rolls from players in the combat tracker",
     "author": "Steven Fuqua",

--- a/src/HiddenInitiativeCombatTracker.spec.ts
+++ b/src/HiddenInitiativeCombatTracker.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import {
-    HiddenInitiativeCombatTracker,
+    WithHiddenInitiative,
     SORT_KEY,
     TURN_INDEX,
     InitiativeStatus,
@@ -46,6 +46,18 @@ const baseGetData = jest.fn<Data, []>();
 global.CombatTracker.prototype.getData = baseGetData;
 
 // @ts-ignore
+if (!global.CombatTracker) {
+    // @ts-ignore
+    global.CombatTracker = class {
+        getData = baseGetData;
+    };
+
+    throw new Error("xyz");
+} else {
+    throw new Error("asdf");
+}
+
+// @ts-ignore
 global.game = {
     settings: {
         get: jest.fn(),
@@ -76,10 +88,11 @@ function mockSettings(npcRoll: RollVisibility, playerRoll: RollVisibility, revea
 }
 
 describe("HiddenInitiativeCombatTracker", () => {
-    let tracker: HiddenInitiativeCombatTracker;
+    let tracker: CombatTracker;
 
     beforeEach(() => {
-        tracker = new HiddenInitiativeCombatTracker();
+        const TrackerClass = WithHiddenInitiative(CombatTracker);
+        tracker = new TrackerClass();
     });
 
     afterEach(() => {

--- a/src/HiddenInitiativeCombatTracker.spec.ts
+++ b/src/HiddenInitiativeCombatTracker.spec.ts
@@ -8,6 +8,7 @@ import {
     STATUS,
     UNKNOWN_MASK,
     REVEALED_MASK,
+    HiddenInitiativeCombatTracker,
 } from "./HiddenInitiativeCombatTracker";
 import { SettingName, RollVisibility } from "./settings";
 
@@ -46,18 +47,6 @@ const baseGetData = jest.fn<Data, []>();
 global.CombatTracker.prototype.getData = baseGetData;
 
 // @ts-ignore
-if (!global.CombatTracker) {
-    // @ts-ignore
-    global.CombatTracker = class {
-        getData = baseGetData;
-    };
-
-    throw new Error("xyz");
-} else {
-    throw new Error("asdf");
-}
-
-// @ts-ignore
 global.game = {
     settings: {
         get: jest.fn(),
@@ -88,7 +77,7 @@ function mockSettings(npcRoll: RollVisibility, playerRoll: RollVisibility, revea
 }
 
 describe("HiddenInitiativeCombatTracker", () => {
-    let tracker: CombatTracker;
+    let tracker: HiddenInitiativeCombatTracker;
 
     beforeEach(() => {
         const TrackerClass = WithHiddenInitiative(CombatTracker);

--- a/src/HiddenInitiativeCombatTracker.ts
+++ b/src/HiddenInitiativeCombatTracker.ts
@@ -170,6 +170,3 @@ export const WithHiddenInitiative = <T extends CombatTrackerConstructor>(
 
     return HiddenInitiativeMixinClass;
 };
-
-const MixedIn = WithHiddenInitiative(CombatTracker);
-export const tracker = new MixedIn();

--- a/src/HiddenInitiativeCombatTracker.ts
+++ b/src/HiddenInitiativeCombatTracker.ts
@@ -168,5 +168,6 @@ export const WithHiddenInitiative = <T extends CombatTrackerConstructor>(
         };
     }
 
+    Object.defineProperty(HiddenInitiativeMixinClass.prototype.constructor, "name", { value: "CombatTracker" });
     return HiddenInitiativeMixinClass;
 };

--- a/src/HiddenInitiativeCombatTracker.ts
+++ b/src/HiddenInitiativeCombatTracker.ts
@@ -62,7 +62,14 @@ export type HiddenInitiativeCombatTrackerData = Omit<CombatTrackerData, "turns">
     >;
 };
 
+export type HiddenInitiativeCombatTracker = Omit<CombatTracker, "getData"> & {
+    getData(): Promise<HiddenInitiativeCombatTrackerData>;
+};
+
 type CombatTrackerConstructor = new (...args: ConstructorParameters<typeof CombatTracker>) => CombatTracker;
+type HiddenInitiativeCombatTrackerConstructor = new (
+    ...args: ConstructorParameters<typeof CombatTracker>
+) => HiddenInitiativeCombatTracker;
 
 /**
  * Extension of the Foundry VTT CombatTracker that handles massaging the
@@ -70,7 +77,9 @@ type CombatTrackerConstructor = new (...args: ConstructorParameters<typeof Comba
  * Dynamic/runtime extension pattern borrowed from https://www.bryntum.com/blog/the-mixin-pattern-in-typescript-all-you-need-to-know/
  * in order to allow merging classes from different modules.
  */
-export const WithHiddenInitiative = <T extends CombatTrackerConstructor>(BaseTracker: T): CombatTrackerConstructor => {
+export const WithHiddenInitiative = <T extends CombatTrackerConstructor>(
+    BaseTracker: T
+): HiddenInitiativeCombatTrackerConstructor => {
     class HiddenInitiativeMixinClass extends BaseTracker {
         constructor(...args: ConstructorParameters<typeof CombatTracker>) {
             super(...args);

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,7 @@ const ROLL_SHIMMED = Symbol("RollShimmed");
 // 2. Update the rendered HTML with a "..." for unrolled initiative
 // TODO: Group turns into separate lists, with headers.
 Hooks.on(
-    "renderHiddenInitiativeCombatTracker",
+    "renderCombatTracker",
     (tracker: CombatTracker, html: JQuery<HTMLElement>, data: HiddenInitiativeCombatTrackerData) => {
         // Monkeypatch the Combat.rollInitiative function if we haven't already for this instance
         const shimmedCombat = (data.combat as unknown) as { [ROLL_SHIMMED]?: boolean };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import {
-    HiddenInitiativeCombatTracker,
     HiddenInitiativeCombatTrackerData,
     STATUS,
     InitiativeStatus,
+    WithHiddenInitiative,
 } from "./HiddenInitiativeCombatTracker.js";
 import { createRollInitiativeReplacement } from "./createRollInitiativeReplacement.js";
 import { loc } from "./loc.js";
@@ -88,7 +88,7 @@ Hooks.on("init", () => {
     });
 
     // Override the default CombatTracker with our extension
-    CONFIG.ui.combat = HiddenInitiativeCombatTracker;
+    CONFIG.ui.combat = WithHiddenInitiative(CONFIG.ui.combat);
 });
 
 /**


### PR DESCRIPTION
- Use a mixin pattern for the overridden CombatTracker instead of just stomping over it
- Give the constructor the name "CombatTracker" so that other modules' `renderCombatTracker` hooks function as expected

In particular, this change should address problems with the "Combat Enhancements" module.